### PR TITLE
Fix non-determinism in getting the most recent job for a database

### DIFF
--- a/powershell/restoreSQLDBs/restoreSQLDBs.ps1
+++ b/powershell/restoreSQLDBs/restoreSQLDBs.ps1
@@ -62,8 +62,9 @@ $searchresults = api get "/searchvms?environment=SQL&entityTypes=kSQL&vmName=$so
 $dbresults = $searchresults.vms | Where-Object {$_.vmDocument.objectAliases -eq $sourceServer}
 
 ### if there are multiple results (e.g. old/new jobs?) select the one with the newest snapshot 
-$dbresults = ($dbresults | Sort-Object -Property @{Expression={$_.vmDocument.versions[0].snapshotTimestampUsecs}; Ascending = $False}) |
-                           Sort-Object -Property @{Expression={$_.vmDocument.objectName}} -Unique
+$dbresults = $dbresults | Sort-Object -Property @{Expression={$_.vmDocument.versions[0].snapshotTimestampUsecs}; Ascending = $False} |
+                          Group-Object -Property @{Expression={$_.vmDocument.objectName}} |
+                          ForEach-Object {$_.Group[0]}
 
 ### narrow by sourceInstance
 if($sourceInstance){

--- a/sql-scripts/restoreSQLDBs/restoreSQLDBs.ps1
+++ b/sql-scripts/restoreSQLDBs/restoreSQLDBs.ps1
@@ -62,8 +62,9 @@ $searchresults = api get "/searchvms?environment=SQL&entityTypes=kSQL&vmName=$so
 $dbresults = $searchresults.vms | Where-Object {$_.vmDocument.objectAliases -eq $sourceServer}
 
 ### if there are multiple results (e.g. old/new jobs?) select the one with the newest snapshot 
-$dbresults = ($dbresults | Sort-Object -Property @{Expression={$_.vmDocument.versions[0].snapshotTimestampUsecs}; Ascending = $False}) |
-                           Sort-Object -Property @{Expression={$_.vmDocument.objectName}} -Unique
+$dbresults = $dbresults | Sort-Object -Property @{Expression={$_.vmDocument.versions[0].snapshotTimestampUsecs}; Ascending = $False} |
+                          Group-Object -Property @{Expression={$_.vmDocument.objectName}} |
+                          ForEach-Object {$_.Group[0]}
 
 ### narrow by sourceInstance
 if($sourceInstance){


### PR DESCRIPTION
Fixes #30 

Instead of piping the `vmDocument`s to multiple sorts, first sort by `snapshotTimestampUsecs` descending then group by the `vmDocument`'s `objectName`.  Finally, iterate through each group and select the first (newest) job.

