### PR TITLE
Fixed bug with multiple objects for Object Protection Details

### DIFF
--- a/powershell/objectProtectionDetails/objectProtectionDetails.ps1
+++ b/powershell/objectProtectionDetails/objectProtectionDetails.ps1
@@ -75,14 +75,14 @@ foreach($v in $vip){
         if($null -ne $objectId){
             $foundObject[$object] = $True
             # find protection job
-            $jobs = $jobs | Where-Object {
+            $object_jobs = $jobs | Where-Object {
                 $objectId -in $_.sourceIds -or
                 $objectId -in $_.sourceSpecialParameters.oracleSpecialParameters.applicationEntityIds -or
                 $objectId -in $_.sourceSpecialParameters.sqlSpecialParameters.applicationEntityIds
             }
-            if($null -ne $jobs){
+            if($null -ne $object_jobs){
                 $objectProtected[$object] = $True
-                foreach($job in $jobs){
+                foreach($job in $object_jobs){
                     "`n$($cluster.name): $global:object ($($job.name))`n"
                     "Start Time          End Time            Type         Object   Read       Logical Size"
                     "------------------  ------------------  -----------  -------  ---------  ------------"


### PR DESCRIPTION
The 'jobs' variable was used to store all protection jobs but in line 78 it was overwritten by the jobs being used to protect an object:
```# find protection job
$jobs = $jobs | Where-Object {
    $objectId -in $_.sourceIds -or
    $objectId -in $_.sourceSpecialParameters.oracleSpecialParameters.applicationEntityIds -or
    $objectId -in $_.sourceSpecialParameters.sqlSpecialParameters.applicationEntityIds
}
```
This causes issues for multiple objects (in the following iterations of the loop) when it says the object is not protected as it only checks the filtered jobs from the previous object.