### PR TITLE
Update viewGrowth.ps1 for non standard ports

### DIFF
--- a/reports/powershell/viewGrowth/viewGrowth.ps1
+++ b/reports/powershell/viewGrowth/viewGrowth.ps1
@@ -17,11 +17,14 @@ apiauth -vip $vip -username $username -domain $domain
 
 $views = (api get views).views | Sort-Object -Property name
 
+# Replace colon with underscore in the VIP variable since any nonstandard port must specify :<port> but powershell interprets : as a 'drive' 
+$vipWithoutColon = $vip -replace ":", "_"
+
 $endDate = get-date
 $startDate = $endDate.AddDays(-$days)
 $startDateString = ([datetime]$startDate).ToString("yyyy-MM-dd")
 $endDateString = ([datetime]$endDate).ToString("yyyy-MM-dd")
-$outfile = "viewGrowth_$($vip)_$($startDateString)_$($endDateString).csv"
+$outfile = "viewGrowth_$($vipWithoutColon)_$($startDateString)_$($endDateString).csv"
 
 $startDateMsecs = (dateToUsecs $startDate)/1000
 $endDateMsecs = (dateToUsecs $endDate)/1000


### PR DESCRIPTION
Error when running pwsh / RT (As an SRE) :Cannot find drive. A drive with the name 'viewGrowth_localhost' does not exist.

Reason: Powershell is interpreting VIP:port as a drive mapping in the out-file parameter

@bseltz-cohesity 