### PR TITLE
avoid NoneTypeError if regions are not configured

### DIFF
--- a/reports/helios-reporting/python/heliosReport/heliosReport.py
+++ b/reports/helios-reporting/python/heliosReport/heliosReport.py
@@ -93,8 +93,9 @@ allClusters = heliosClusters()
 for selectedCluster in allClusters:
     selectedCluster['id'] = '%s:%s' % (selectedCluster['clusterId'], selectedCluster['clusterIncarnationId'])
 regions = api('get', 'dms/regions', mcmv2=True)
-for region in regions['regions']:
-    allClusters.append(region)
+if regions:
+    for region in regions['regions']:
+        allClusters.append(region)
 
 selectedClusters = allClusters
 


### PR DESCRIPTION
If no clusters have regions configured in MCM, iterating over regions['regions'] will throw a NoneType Error as no regions are returned and None is not iterable.