### PR TITLE
M365 PST download script fails for deleted users due to name vs SMTP mismatch.

### DIFF
--- a/powershell/downloadM365MailboxPST/downloadM365MailboxPST.ps1
+++ b/powershell/downloadM365MailboxPST/downloadM365MailboxPST.ps1
@@ -112,7 +112,7 @@ $recoveryParams = @{
 
 foreach($sourceUser in $sourceUserNames){
     $userSearch = api get -v2 "data-protect/search/protected-objects?snapshotActions=RecoverMailbox&searchString=$sourceUser&environments=kO365"
-    $userObjs = $userSearch.objects | Where-Object {$_.name -eq $sourceUser}
+    $userObjs = $userSearch.objects | Where-Object {$_.name -eq $sourceUser -or ($_.o365Params -and $_.o365Params.primarySMTPAddress -eq $sourceUser)}
     if(!$userObjs){
         foreach($userObj in $userSearch.objects){
             $userSource = api get protectionSources/objects/$($userObj.id)

--- a/python/downloadM365MailboxPST/downloadM365MailboxPST.py
+++ b/python/downloadM365MailboxPST/downloadM365MailboxPST.py
@@ -119,7 +119,7 @@ recoveryParams = {
 
 for sourceUser in sourceusernames:
     userSearch = api('get', 'data-protect/search/protected-objects?snapshotActions=RecoverMailbox&searchString=%s&environments=kO365' % sourceUser, v=2)
-    userObjs = [o for o in userSearch['objects'] if o['name'].lower() == sourceUser.lower()]
+    userObjs = [o for o in userSearch['objects'] if o['name'].lower() == sourceUser.lower() or o.get('o365Params', {}).get('primarySMTPAddress', '').lower() == sourceUser.lower()]
     if userSearch is not None and 'objects' in userSearch and userSearch['objects'] is not None and len(userSearch['objects']) > 0 and userObjs is None or len(userObjs) == 0:
         for userObj in userSearch['objects']:
             userSource = api('get', 'protectionSources/objects/%s' % userObj['id'])


### PR DESCRIPTION
The script matches sourceUser (SMTP) against the name field (display name) in search results, which never matches. The fallback path queries the magneto entity hierarchy, which no longer contains deleted users. 

Fix: match on o365Params.primarySMTPAddress in the initial filter.